### PR TITLE
Fix typo in ArticleCategory docstring

### DIFF
--- a/apps/guides/models.py
+++ b/apps/guides/models.py
@@ -69,7 +69,7 @@ class ArticleCategory(BaseModel, ActiveModel):
         return self.name
     
     def get_all_subcategories(self):
-        """Возвращает все подкategории рекурсивно"""
+        """Возвращает все подкатегории рекурсивно"""
         subcategories = list(self.subcategories.filter(is_active=True))
         for subcategory in self.subcategories.filter(is_active=True):
             subcategories.extend(subcategory.get_all_subcategories())


### PR DESCRIPTION
## Summary
- fix Russian text typo in `ArticleCategory.get_all_subcategories` docstring

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: apps.users.urls.webhook_urls)*

------
https://chatgpt.com/codex/tasks/task_b_68474a05bb24832092be72b5c8d5a972