### PR TITLE
Fix telegram auth dev route

### DIFF
--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -2,6 +2,7 @@
 URL конфигурация для пользователей
 """
 from django.urls import path
+from django.conf import settings
 from rest_framework_simplejwt.views import TokenRefreshView
 
 from .views import (
@@ -16,7 +17,6 @@ app_name = 'users'
 urlpatterns = [
     # Аутентификация
     path('telegram/', TelegramAuthView.as_view(), name='telegram-auth'),
-    path('telegram-simple/', telegram_mini_app_auth, name='telegram-simple-auth'),
     path('refresh/', TokenRefreshView.as_view(), name='token-refresh'),
     path('me/', CurrentUserView.as_view(), name='current-user'),
     
@@ -40,3 +40,7 @@ urlpatterns = [
     path('webhook/telegram/', TelegramWebhookView.as_view(), name='telegram-webhook'),
     path('bot/user/<str:telegram_id>/', BotUserInfoView.as_view(), name='bot-user-info'),
 ]
+
+# Упрощенный эндпоинт авторизации используется только в режиме разработки
+if settings.DEBUG:
+    urlpatterns.insert(1, path('telegram-simple/', telegram_mini_app_auth, name='telegram-simple-auth'))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = onboarding.settings.testing
+DJANGO_SETTINGS_MODULE = onboarding.settings
 python_files = tests/test_*.py
 


### PR DESCRIPTION
## Summary
- restrict simplified telegram auth URL to DEBUG mode
- point tests to default settings

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6848546e6bc88320b866e39cdde0916d