### PR TITLE
Fix duplicate role on telegram mini app auth

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -399,10 +399,10 @@ def telegram_mini_app_auth(request):
                 telegram_username=telegram_data.get('username', '')
             )
             
-            # Назначаем базовую роль
+            # Назначаем базовую роль, если она ещё не присвоена
             try:
                 user_role = Role.objects.get(name='user')
-                UserRole.objects.create(user=user, role=user_role)
+                UserRole.objects.get_or_create(user=user, role=user_role)
             except Role.DoesNotExist:
                 pass
         


### PR DESCRIPTION
## Summary
- prevent duplicate role assignment when a new user authenticates via simplified Telegram endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68489f21752483208a3d33441d508a39