### PR TITLE
Add basic onboarding frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ __pycache__/
 staticfiles/
 media/
 logs/
+# Coverage
+.coverage
+htmlcov/
+
+# Frontend
+frontend/node_modules/
+frontend/package-lock.json

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:8000/api
+VITE_TELEGRAM_BOT_TOKEN=your-bot-token

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,16 @@
+# BudTest Frontend
+
+React-based Telegram Mini App frontend for BudTest. It follows the architecture described in `docs/` and includes basic authentication, flows navigation and step pages.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+Run tests with:
+
+```bash
+npm run test
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "budtest-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint src --ext ts,tsx",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "react-router-dom": "^6.26.0",
+    "@reduxjs/toolkit": "^2.2.0",
+    "react-redux": "^9.1.0",
+    "redux-persist": "^6.0.0",
+    "@telegram-apps/sdk-react": "^1.1.0",
+    "axios": "^1.7.0",
+    "framer-motion": "^11.0.0",
+    "@tanstack/react-query": "^5.34.0",
+    "react-hook-form": "^7.53.0",
+    "@hookform/resolvers": "^3.3.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.5.0",
+    "vite": "^5.4.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.0.0",
+    "prettier": "^3.2.5",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.1.2"
+    ,"jsdom": "^24.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BudTest</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,0 +1,39 @@
+import { Route, Routes, Navigate } from 'react-router-dom';
+import { DashboardPage } from '../pages/Dashboard';
+import { AuthPage } from '../pages/AuthPage';
+import { FlowDetailPage } from '../pages/FlowDetail';
+import { StepContentPage } from '../pages/StepContent';
+import { ProtectedRoute } from '@/shared/components/ProtectedRoute';
+
+export const App = () => {
+  return (
+    <Routes>
+      <Route path="/auth" element={<AuthPage />} />
+      <Route
+        path="/"
+        element={
+          <ProtectedRoute>
+            <DashboardPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/flows/:flowId"
+        element={
+          <ProtectedRoute>
+            <FlowDetailPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/flows/:flowId/steps/:stepId"
+        element={
+          <ProtectedRoute>
+            <StepContentPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route path="*" element={<Navigate to="/" />} />
+    </Routes>
+  );
+};

--- a/frontend/src/app/providers/QueryClientProvider.tsx
+++ b/frontend/src/app/providers/QueryClientProvider.tsx
@@ -1,0 +1,8 @@
+import { QueryClient, QueryClientProvider as Provider } from '@tanstack/react-query';
+import { PropsWithChildren } from 'react';
+
+const queryClient = new QueryClient();
+
+export const AppQueryClientProvider = ({ children }: PropsWithChildren) => (
+  <Provider client={queryClient}>{children}</Provider>
+);

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -1,0 +1,11 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { authReducer } from '@/features/auth/slice';
+
+export const store = configureStore({
+  reducer: {
+    auth: authReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/frontend/src/features/auth/components/LocalAuth.tsx
+++ b/frontend/src/features/auth/components/LocalAuth.tsx
@@ -1,0 +1,58 @@
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useAppDispatch } from '../hooks/useAuth';
+import { loginSuccess } from '../slice';
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(4),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+export const LocalAuth = () => {
+  const dispatch = useAppDispatch();
+  const { register, handleSubmit, formState } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+  });
+
+  const onSubmit = (data: FormValues) => {
+    // mock login success
+    dispatch(
+      loginSuccess({
+        user: {
+          id: 1,
+          firstName: 'Dev',
+          roles: ['user'],
+        },
+        tokens: { access: 'mock', refresh: 'mock' },
+      })
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 p-4">
+      <input
+        className="border p-2 w-full"
+        placeholder="Email"
+        {...register('email')}
+      />
+      <input
+        className="border p-2 w-full"
+        type="password"
+        placeholder="Password"
+        {...register('password')}
+      />
+      {formState.errors.email && (
+        <p className="text-red-500 text-sm">Invalid email</p>
+      )}
+      <button
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+        type="submit"
+      >
+        Login
+      </button>
+    </form>
+  );
+};

--- a/frontend/src/features/auth/hooks/useAuth.ts
+++ b/frontend/src/features/auth/hooks/useAuth.ts
@@ -1,0 +1,10 @@
+import { useSelector, TypedUseSelectorHook, useDispatch } from 'react-redux';
+import type { RootState, AppDispatch } from '@/app/store';
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+
+export const useAuth = () => {
+  const { user, tokens, isLoading } = useAppSelector((state) => state.auth);
+  return { user, tokens, isLoading };
+};

--- a/frontend/src/features/auth/slice.ts
+++ b/frontend/src/features/auth/slice.ts
@@ -1,0 +1,44 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { User, Tokens } from './types';
+
+interface AuthState {
+  user: User | null;
+  tokens: Tokens | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+const initialState: AuthState = {
+  user: null,
+  tokens: null,
+  isLoading: false,
+  error: null,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    loginStart(state) {
+      state.isLoading = true;
+      state.error = null;
+    },
+    loginSuccess(state, action: PayloadAction<{ user: User; tokens: Tokens }>) {
+      state.user = action.payload.user;
+      state.tokens = action.payload.tokens;
+      state.isLoading = false;
+    },
+    loginFailure(state, action: PayloadAction<string>) {
+      state.error = action.payload;
+      state.isLoading = false;
+    },
+    logout(state) {
+      state.user = null;
+      state.tokens = null;
+    },
+  },
+});
+
+export const { loginStart, loginSuccess, loginFailure, logout } = authSlice.actions;
+
+export const authReducer = authSlice.reducer;

--- a/frontend/src/features/auth/types.ts
+++ b/frontend/src/features/auth/types.ts
@@ -1,0 +1,12 @@
+export interface User {
+  id: number;
+  firstName: string;
+  lastName?: string;
+  username?: string;
+  roles: string[];
+}
+
+export interface Tokens {
+  access: string;
+  refresh: string;
+}

--- a/frontend/src/features/flows/api/hooks.ts
+++ b/frontend/src/features/flows/api/hooks.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '@/shared/api/client';
+
+export const useFlows = () =>
+  useQuery({
+    queryKey: ['flows'],
+    queryFn: async () => {
+      const { data } = await apiClient.get('/my/flows');
+      return data;
+    },
+  });
+
+export const useFlow = (id: string) =>
+  useQuery({
+    queryKey: ['flow', id],
+    queryFn: async () => {
+      const { data } = await apiClient.get(`/flows/${id}`);
+      return data;
+    },
+    enabled: Boolean(id),
+  });

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
+import { AppQueryClientProvider } from './app/providers/QueryClientProvider';
+import { App } from './app/App';
+import { store } from './app/store';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <Provider store={store}>
+      <AppQueryClientProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AppQueryClientProvider>
+    </Provider>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/AuthPage.tsx
+++ b/frontend/src/pages/AuthPage.tsx
@@ -1,0 +1,10 @@
+import { LocalAuth } from '@/features/auth/components/LocalAuth';
+
+export const AuthPage = () => {
+  return (
+    <div className="flex flex-col items-center mt-10">
+      <h1 className="text-lg font-bold mb-4">BudTest Login</h1>
+      <LocalAuth />
+    </div>
+  );
+};

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
+import { DashboardPage } from './Dashboard';
+import { store } from '@/app/store';
+
+describe('DashboardPage', () => {
+  it('renders heading', () => {
+    const client = new QueryClient();
+    client.setQueryData(['flows'], [{ id: '1', title: 'Test Flow' }]);
+    const { getByText } = render(
+      <Provider store={store}>
+        <QueryClientProvider client={client}>
+          <BrowserRouter>
+            <DashboardPage />
+          </BrowserRouter>
+        </QueryClientProvider>
+      </Provider>
+    );
+
+    expect(getByText(/My Flows/)).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom';
+import { useFlows } from '@/features/flows/api/hooks';
+import { PageLayout } from '@/shared/components/PageLayout';
+
+export const DashboardPage = () => {
+  const { data: flows, isLoading } = useFlows();
+
+  if (isLoading) return <PageLayout>Loading...</PageLayout>;
+
+  return (
+    <PageLayout>
+      <h1 className="text-xl font-bold mb-4">My Flows</h1>
+      <ul className="space-y-2">
+        {flows?.map((flow: any) => (
+          <li key={flow.id}>
+            <Link className="text-blue-600 underline" to={`/flows/${flow.id}`}>
+              {flow.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </PageLayout>
+  );
+};

--- a/frontend/src/pages/FlowDetail.tsx
+++ b/frontend/src/pages/FlowDetail.tsx
@@ -1,0 +1,39 @@
+import { useParams, Link } from 'react-router-dom';
+import { PageLayout, PageLoader, NotFound } from '@/shared/components/PageLayout';
+
+// Mock data
+const flows = {
+  '1': {
+    id: '1',
+    title: 'Onboarding Flow',
+    steps: [
+      { id: 'step1', title: 'Welcome' },
+      { id: 'step2', title: 'First Task' },
+    ],
+  },
+};
+
+export const FlowDetailPage = () => {
+  const { flowId } = useParams<{ flowId: string }>();
+  const flow = flows[flowId ?? ''];
+
+  if (!flow) return <NotFound />;
+
+  return (
+    <PageLayout>
+      <h1 className="text-xl font-bold mb-4">{flow.title}</h1>
+      <ul className="space-y-2">
+        {flow.steps.map((s) => (
+          <li key={s.id}>
+            <Link
+              className="text-blue-600 underline"
+              to={`/flows/${flow.id}/steps/${s.id}`}
+            >
+              {s.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </PageLayout>
+  );
+};

--- a/frontend/src/pages/StepContent.tsx
+++ b/frontend/src/pages/StepContent.tsx
@@ -1,0 +1,27 @@
+import { useParams } from 'react-router-dom';
+import { PageLayout } from '@/shared/components/PageLayout';
+
+// Mock
+const steps = {
+  step1: {
+    id: 'step1',
+    content: 'Welcome to BudTest! Read the article and proceed.',
+  },
+  step2: {
+    id: 'step2',
+    content: 'Complete your first task.',
+  },
+};
+
+export const StepContentPage = () => {
+  const { stepId } = useParams<{ stepId: string }>();
+  const step = steps[stepId ?? ''];
+
+  if (!step) return <PageLayout>Step not found</PageLayout>;
+
+  return (
+    <PageLayout>
+      <p>{step.content}</p>
+    </PageLayout>
+  );
+};

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { store } from '@/app/store';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+
+export const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+apiClient.interceptors.request.use((config) => {
+  const token = store.getState().auth.tokens?.access;
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});

--- a/frontend/src/shared/components/PageLayout.tsx
+++ b/frontend/src/shared/components/PageLayout.tsx
@@ -1,0 +1,13 @@
+import { PropsWithChildren } from 'react';
+
+export const PageLayout = ({ children }: PropsWithChildren) => {
+  return <div className="p-4 max-w-screen-md mx-auto">{children}</div>;
+};
+
+export const PageLoader = () => (
+  <div className="p-4">Loading...</div>
+);
+
+export const NotFound = () => (
+  <div className="p-4">Not Found</div>
+);

--- a/frontend/src/shared/components/ProtectedRoute.tsx
+++ b/frontend/src/shared/components/ProtectedRoute.tsx
@@ -1,0 +1,22 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+
+type Props = {
+  children: JSX.Element;
+  requiredRoles?: string[];
+};
+
+export const ProtectedRoute = ({ children, requiredRoles }: Props) => {
+  const { user } = useAuth();
+
+  if (!user) {
+    return <Navigate to="/auth" />;
+  }
+
+  if (requiredRoles && requiredRoles.length) {
+    const hasRole = user.roles.some((r) => requiredRoles.includes(r));
+    if (!hasRole) return <Navigate to="/" />;
+  }
+
+  return children;
+};

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "react-jsx",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- expand React frontend with Redux slices
- add protected routing, query client provider, and API hooks
- create pages for auth, dashboard, and flow details
- set up Vitest with jsdom and add a simple test
- update README and package configuration

## Testing
- `pytest --cov=apps --cov-report=term-missing --cov-report=html`
- `npm run test` (frontend)

------
https://chatgpt.com/codex/tasks/task_b_684ef0045ab083208d80c8e5b4731070