### PR TITLE
Fix API pagination for tests

### DIFF
--- a/onboarding/settings.py
+++ b/onboarding/settings.py
@@ -124,6 +124,11 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
     ],
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    # Включаем пагинацию по умолчанию, чтобы ответы ListAPIView
+    # содержали поля count/next/previous/results, как ожидают тесты.
+    'DEFAULT_PAGINATION_CLASS':
+        'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 10,
 }
 
 # Internationalization


### PR DESCRIPTION
## Summary
- enable default pagination in DRF settings so list endpoints return `count` and `results`

## Testing
- `pytest --cov=apps --cov-report=term-missing --cov-report=html`

------
https://chatgpt.com/codex/tasks/task_b_6851a551ae388320823b5a09a7cb75bb